### PR TITLE
Fix corner case for empty R_LIBS_USER

### DIFF
--- a/src/library.rs
+++ b/src/library.rs
@@ -377,6 +377,7 @@ pub fn library_update_rprofile(rver: &str) -> Result<(), Box<dyn Error>> {
 ## rig R_LIBS_USER start
 local({
   userlibs <- strsplit(Sys.getenv("R_LIBS_USER"), .Platform$path.sep)[[1]]
+  if (length(userlibs) == 0) return()
   if (userlibs[[1]] == "NULL") return()
   userlib1 <- userlibs[1]
   dir.create(userlib1, recursive = TRUE, showWarnings = FALSE)


### PR DESCRIPTION
Downstream: https://github.com/rstudio/renv/issues/1020

I don't understand enough about this problem yet, but this change in my local `/Library/Frameworks/R.framework/Versions/4.1-arm64/Resources/library/base/R/Rprofile` fixed the symptoms.

How do I reapply this change to all installations?