### PR TITLE
Remove unnecessary regex

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -575,12 +575,10 @@ fn system_make_orthogonal(vers: Option<Vec<String>>) -> Result<(), Box<dyn Error
 fn is_orthogonal(ver: &str) -> Result<bool, Box<dyn Error>> {
     let base = Path::new(R_ROOT).join(&ver);
     let re = Regex::new("R[.]framework/Resources")?;
-    let re2 = Regex::new("[-]F/Library/Frameworks/R[.]framework/[.][.]")?;
     let rfile = base.join("Resources/bin/R");
     let lines = read_lines(&rfile)?;
     let mch = grep_lines(&re, &lines);
-    let mch2 = grep_lines(&re2, &lines);
-    Ok(mch.len() == 0 && mch2.len() == 0)
+    Ok(mch.len() == 0)
 }
 
 fn make_orthogonal_(base: &Path, ver: &str) -> Result<(), Box<dyn Error>> {


### PR DESCRIPTION
As discussed elsewhere, we think `re2` is relevant in `make_orthogonal_()` (specifically: relevant to compilation config). But I don't think you would ever encounter it in a "binary" (in the shell script sense).