### PR TITLE
"Linux" instead of "Windows"

### DIFF
--- a/src/linux.rs
+++ b/src/linux.rs
@@ -570,22 +570,22 @@ pub fn sc_system_allow_debugger_rstudio(_args: &ArgMatches) -> Result<(), Box<dy
 }
 
 pub fn sc_system_make_orthogonal(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    // Nothing to do on Windows
+    // Nothing to do on Linux
     Ok(())
 }
 
 pub fn sc_system_fix_permissions(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    // Nothing to do on Windows
+    // Nothing to do on Linux
     Ok(())
 }
 
 pub fn sc_system_forget() -> Result<(), Box<dyn Error>> {
-    // Nothing to do on Windows
+    // Nothing to do on Linux
     Ok(())
 }
 
 pub fn sc_system_no_openmp(_args: &ArgMatches) -> Result<(), Box<dyn Error>> {
-    // Nothing to do on Windows
+    // Nothing to do on Linux
     Ok(())
 }
 


### PR DESCRIPTION
This is pretty meaningless but just something I noticed during my recent tour of rig.