### PR TITLE
Include certs in Linux tar.gz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,12 @@ rig-$(VERSION).tar.gz: target/release/rig
 	mkdir -p build/bin
 	mkdir -p build/share/bash-completion/completions
 	mkdir -p build/share/zsh/site-functions
+	ls -l target/release
 	cp target/release/rig build/bin
 	find target/release/build -name _rig -exec cp \{\} build/share/zsh/site-functions \; 
-	find target/release/build -name rig.bash -exec cp \{\} build/share/bash-completion/completions \; 
+	find target/release/build -name rig.bash -exec cp \{\} build/share/bash-completion/completions \;
+	mkdir -p build/share/rig
+	curl -L -o build/share/rig/cacert.pem 'https://curl.se/ca/cacert.pem'
 	tar cz -C build -f $@ bin share
 
 # -------------------------------------------------------------------------

--- a/src/escalate.rs
+++ b/src/escalate.rs
@@ -50,6 +50,8 @@ pub fn escalate(task: &str) -> Result<(), Box<dyn Error>> {
             "LC_MONETARY",
             "LC_NUMERIC",
             "LC_TIME",
+            "SSL_CERT_FILE",
+            "SSL_CERT_DIR",
         ])?;
     }
 

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -11,7 +11,7 @@ use std::{file, line};
 
 use clap::ArgMatches;
 use simple_error::*;
-use simplelog::{trace,debug, info, warn};
+use simplelog::{trace, debug, info, warn};
 
 use crate::resolve::resolve_versions;
 use crate::rversion::*;
@@ -855,4 +855,26 @@ fn check_usr_bin_sed(rver: &str) -> Result<(), Box<dyn Error>> {
            Run `ln -s /bin/sed /usr/bin/sed` as the root user to fix this,\n        \
            and then run rig again."
         );
+}
+
+pub fn set_cert_envvar() {
+    match std::env::var("SSL_CERT_FILE") {
+        Ok(_)  => {
+            debug!("SSL_CERT_FILE is already set, keeping it.");
+            return;
+        },
+        Err(_) => {
+            let scertpath = "/usr/local/share/rig/cacert.pem";
+            let certpath = std::path::Path::new(scertpath);
+            if certpath.exists() {
+                debug!("Using embedded SSL certificates via SSL_CERT_FILE");
+                std::env::set_var("SSL_CERT_FILE", scertpath);
+            } else {
+                debug!(
+                    "{} does not exist, using system SSL certificates",
+                    scertpath
+                );
+            }
+        }
+    };
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,6 @@ fn main() {
 }
 
 fn main_() -> i32 {
-    unset_r_envvars();
     let args = parse_args();
 
     // -- set up logger output --------------------------------------------
@@ -86,6 +85,11 @@ fn main_() -> i32 {
         }
         _ => {}
     };
+
+    unset_r_envvars();
+
+    #[cfg(target_os = "linux")]
+    set_cert_envvar();
 
     // --------------------------------------------------------------------
 


### PR DESCRIPTION
And use them, unless SSL_CERT_* env vars are
set explicitly.

Closes #176 