### PR TITLE
add additional installation instructions for Pop!_OS (Ubuntu 22.04 LTS) users

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,13 @@ If you already added both the key and the repository, then install the
     `which sudo` apt update
     `which sudo` apt install r-rig
 
+##### Installing rig on Ubuntu and Debian (DEB package) on Pop!_OS (Ubuntu 22.04 LTS)
+
+On Pop!_OS you can manually set the RIG_PLATFORM by editing your environment variables.
+
+    `which sudo` echo -e '\n# Customize RIG_PLATFORM for r-rig' >> ~/.profile
+    `which sudo` echo -e 'export RIG_PLATFORM="ubuntu-22.04"' >> ~/.profile
+
 #### Installing rig on RHEL, Fedora, CentOS, Rocky Linux, Almalinux, etc. (RPM package) <a id="id-rhel-fedora-centos-rocky-linux-almalinux-etc-rpm-package">
 
 On most RPM based distros (except for OpenSUSE and SLES) you can install

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ On Pop!_OS you can manually set the RIG_PLATFORM by editing your environment var
 
     `which sudo` echo -e '\n# Customize RIG_PLATFORM for r-rig' >> ~/.profile
     `which sudo` echo -e 'export RIG_PLATFORM="ubuntu-22.04"' >> ~/.profile
+    `which sudo` source ~/.profile
 
 #### Installing rig on RHEL, Fedora, CentOS, Rocky Linux, Almalinux, etc. (RPM package) <a id="id-rhel-fedora-centos-rocky-linux-almalinux-etc-rpm-package">
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ tracker](https://github.com/r-lib/rig/issues).
 - [Linux](#id-linux)
   - [Supported Linux distributions](#id-supported-linux-distributions)
   - [Ubuntu and Debian (DEB package)](#id-ubuntu-and-debian-deb-package)
+  - [Pop!_OS (DEB package)](#id-popos-deb-package)
   - [RHEL, Fedora, CentOS, Rocky Linux, Almalinux, etc. (RPM
     package)](#id-rhel-fedora-centos-rocky-linux-almalinux-etc-rpm-package)
   - [OpenSUSE and SLES (RPM package)](#id-opensuse-and-sles-rpm-package)
@@ -198,7 +199,22 @@ If you already added both the key and the repository, then install the
     `which sudo` apt update
     `which sudo` apt install r-rig
 
-##### Installing rig on Ubuntu and Debian (DEB package) on Pop!_OS (Ubuntu 22.04 LTS)
+#### Installing rig on Pop!_OS (Ubuntu 22.04 LTS) (DEB package) <a id="id-popos-deb-package">
+
+On Pop!_OS you can install packages from any Ubuntu or Debian distro, you can use our package repository to
+install rig. First you add our key to your config:
+
+    `which sudo` curl -L https://rig.r-pkg.org/deb/rig.gpg -o /etc/apt/trusted.gpg.d/rig.gpg
+
+Then add the rig repository:
+
+    `which sudo` sh -c 'echo "deb http://rig.r-pkg.org/deb rig main" > /etc/apt/sources.list.d/rig.list'
+
+If you already added both the key and the repository, then install the
+`r-rig` package (`rig` is a different package in Debian and Ubuntu):
+
+    `which sudo` apt update
+    `which sudo` apt install r-rig
 
 On Pop!_OS you can manually set the RIG_PLATFORM by editing your environment variables.
 

--- a/README.md
+++ b/README.md
@@ -216,11 +216,17 @@ If you already added both the key and the repository, then install the
     `which sudo` apt update
     `which sudo` apt install r-rig
 
-On Pop!_OS you can manually set the RIG_PLATFORM by editing your environment variables.
+On Pop!_OS you can manually set the RIG_PLATFORM by editing your environment variables for Bash.
 
     `which sudo` echo -e '\n# Customize RIG_PLATFORM for r-rig' >> ~/.profile
     `which sudo` echo -e 'export RIG_PLATFORM="ubuntu-22.04"' >> ~/.profile
     `which sudo` source ~/.profile
+
+For ZSH you can manually set the RIG_PLATFORM by editing your environment variables with the following instructions.
+
+    `which sudo` echo -e '\n# Customize RIG_PLATFORM for r-rig' >> ~/.zprofile
+    `which sudo` echo -e 'export RIG_PLATFORM="ubuntu-22.04"' >> ~/.zprofile
+    `which sudo` source ~/.zprofile
 
 #### Installing rig on RHEL, Fedora, CentOS, Rocky Linux, Almalinux, etc. (RPM package) <a id="id-rhel-fedora-centos-rocky-linux-almalinux-etc-rpm-package">
 


### PR DESCRIPTION
Merged conflicts and is a resubmittal of https://github.com/r-lib/rig/pull/241

Added an additional snippet from https://github.com/r-lib/rig/issues/206#issuecomment-2057856982 for users on Pop!_OS so they can set a custom RIG_PLATFORM.