### PR TITLE
feat: Add Amazon Linux 2023 support

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -452,7 +452,13 @@ pub fn get_platform(args: &ArgMatches) -> Result<String, Box<dyn Error>> {
         if os == "linux" {
             let dist = detect_platform()?;
             if let (Some(distro), Some(version)) = (dist.distro, dist.version) {
-                os = format!("linux-{}-{}", distro, version);
+                // Amazon Linux 2023 is RHEL 9-compatible; the r-hub API
+                // doesn't know about amzn so we resolve against rhel-9.
+                if distro == "amzn" && version == "2023" {
+                    os = "linux-rhel-9".to_string();
+                } else {
+                    os = format!("linux-{}-{}", distro, version);
+                }
             }
         }
     }

--- a/src/data/repos.json
+++ b/src/data/repos.json
@@ -261,6 +261,18 @@
                     "x86_64",
                     "aarch64"
                 ]
+            },
+            {
+                "name": "P3M",
+                "url": "https://packagemanager.posit.co/cran/__linux__/manylinux_2_28/latest",
+                "platforms": [
+                    "*-linux-gnu-amzn-*"
+                ],
+                "archs": [
+                    "x86_64",
+                    "aarch64"
+                ],
+                "enabled": true
             }
         ]
     },

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -171,6 +171,14 @@ fn select_linux_tools(platform: &OsVersion) -> Result<LinuxTools, Box<dyn Error>
             is_installed: strvec!["rpm", "-q", "{}"],
             delete: strvec!["zypper", "remove", "-y", "{}"],
         })
+    } else if platform.distro.as_deref() == Some("amzn") {
+        Ok(LinuxTools {
+            package_name: "R-{}".to_string(),
+            install: vec![strvec!["dnf", "install", "-y", "{}"]],
+            get_package_name: strvec!["rpm", "-q", "--qf", "%{NAME}", "-p", "{}"],
+            is_installed: strvec!["rpm", "-q", "{}"],
+            delete: strvec!["dnf", "remove", "-y", "{}"],
+        })
     } else if platform.distro.as_deref() == Some("fedora") {
         Ok(LinuxTools {
             package_name: "R-{}".to_string(),


### PR DESCRIPTION
Closes #311

Adds AL2023 as a supported distro. The RHEL 9 R builds from Posit are binary-compatible with AL2023, so this maps the platform for version resolution while keeping AL2023 as its own distro for install tooling and repo setup. As discussed in https://github.com/r-lib/rig/issues/311#issuecomment-4174098723,  this uses the P3M "[manylinux](https://posit.co/blog/introducing-portable-linux-r-binary-packages/])" binary repo, rather than distro-specific RHEL 9 PPM binaries, to avoid the EPEL dependency problem.

### Changes

- **`src/common.rs`**: Map `linux-amzn-2023` to `linux-rhel-9` for the r-hub API version resolution
- **`src/linux.rs`**: Add `"amzn"` branch in `select_linux_tools()` with simple `dnf install`, no EPEL
- **`src/data/repos.json`**: Enable `P3M-manylinux` (`manylinux_2_28`) binaries for `"amzn"` on both x86_64 and aarch64

### Testing

Tested on amazonlinux:2023 (aarch64) in Docker:

```
docker run -it --rm --privileged -v $(pwd):/work amazonlinux:2023 bash
dnf install -y /work/r-rig-0.8.00.1.2.rpm
```

After setup:

```
$ rig system detect-platform
Distribution: amzn
Version:      2023

$ rig resolve release
4.5.3 https://cdn.posit.co/r/rhel-9/pkgs/R-4.5.3-1-1.aarch64.rpm

$ rig add release
[INFO] Running "dnf install -y /tmp/rig/R-4.5.3-1-1.aarch64.rpm"
[INFO] Installing pak for R 4.5.3
```

Start R

```
R
```

P3M manylinux repo is configured automatically, and installing R packages correctly pulls in binaries, e.g.:

```r
> getOption('repos')
P3M  https://packagemanager.posit.co/cran/__linux__/manylinux_2_28/latest

> install.packages('magick')
* installing *binary* package 'magick' ...
* DONE (magick)

> library(magick)
Linking to ImageMagick 6.9.13.25
Enabled features: cairo, fontconfig, freetype, ghostscript, lcms, pango, raw, rsvg, webp, x11

> install.packages('tidyverse')
# all deps install as *binary*
```

P.S. Some R packages with heavy system library dependencies (e.g. `sf`) don't have `manylinux` binaries (only on aarch64?) yet and will fall back to source compilation. But this is a PPM coverage gap, not a rig issue. (E.g., See https://github.com/amazonlinux/amazon-linux-2023/issues/129#issuecomment-3572390465)